### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm run build"

--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 > Provided for the students of the [Bottega Code School](https://bottega.tech/)
 
 *Fork from [es6-webpack2-starter](https://github.com/micooz/es6-webpack2-starter)*
+
+[![Run on Repl.it](https://repl.it/badge/github/mjg1123/ecomm)](https://repl.it/github/mjg1123/ecomm)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@MarquisGaston1/ecomm).